### PR TITLE
test(speed): add large website case over 3,000 pages - hbo

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -10,7 +10,7 @@ jobs:
         uses: ./
         with:
           WEBSITE_URL: https://a11ywatch.com
-          FAIL_TOTAL_COUNT: 3400
+          FAIL_TOTAL_COUNT: 10000
           EXTERNAL: false
           SITE_WIDE: true
           SUBDOMAINS: false

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This action installs the [A11yWatch CLI](https://github.com/A11yWatch/a11ywatch/
 ### Usage
 
 ```yaml
-- uses: a11ywatch/github-action@v1.10.2
+- uses: a11ywatch/github-action@v1.10.4
   with:
     WEBSITE_URL: ${{ secrets.WEBSITE_URL }}
     FIX: true
@@ -17,6 +17,7 @@ This action installs the [A11yWatch CLI](https://github.com/A11yWatch/a11ywatch/
     TLD: true
     FAIL_ERRORS_COUNT: 15
     LIST: true
+    UPGRADE: false
     COMPUTER_VISION_SUBSCRIPTION_KEY: ${{ secrets.COMPUTER_VISION_SUBSCRIPTION_KEY }}
     COMPUTER_VISION_ENDPOINT: ${{ secrets.COMPUTER_VISION_SUBSCRIPTION_KEY }}
 ```
@@ -50,6 +51,11 @@ All inputs are **optional** except $WEBSITE_URL.
 | --------- | ---------------------------------- | ------- |
 | `results` | The results of the report as json. |         |
 | `issues`  | The amount of issues found         |         |
+
+## Common Issues
+
+If you experience issues on your CI you may have to set the `UPGRADE` input to true in order to get the latest docker images.
+We need docker in order to build the appliciation in quickly since we have some services that need to compile that may take awhile.
 
 ## LICENSE
 

--- a/action.yml
+++ b/action.yml
@@ -83,7 +83,7 @@ outputs:
 runs:
   using: composite
   steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v3.0.2
       if: ${{ inputs.FIX == 'true' }}
       with:
         repository: ${{ github.event.pull_request.head.repo.full_name }}
@@ -91,7 +91,7 @@ runs:
         clean: false
 
     - name: Cache cargo crates
-      uses: actions/cache@v3
+      uses: actions/cache@v3.0.5
       id: cache-cargo
       env:
         cache-name: cache-cargo-crates
@@ -101,22 +101,20 @@ runs:
           ~/.cargo/registry/index/
           ~/.cargo/registry/cache/
           ~/.cargo/git/db/
-        key: ${{ runner.os }}-
-        restore-keys: |
-          ${{ runner.os }}-
+        key: ~/.cargo/bin/a11ywatch
 
     - name: Install Rust
-      if: ${{ steps.cache-cargo.outputs.cache-hit != 'true' }}
+      if: steps.cache-cargo.outputs.cache-hit != 'true'
       shell: bash
       run: curl https://sh.rustup.rs -sSf | sh -s -- -y
 
     - name: Install Cargo Update
-      if: ${{ steps.cache-cargo.outputs.cache-hit != 'true' }}
+      if: steps.cache-cargo.outputs.cache-hit != 'true'
       shell: bash
       run: cargo install cargo-update
 
     - name: Install the A11yWatch CLI
-      if: ${{ steps.cache-cargo.outputs.cache-hit != 'true' }}
+      if: steps.cache-cargo.outputs.cache-hit != 'true'
       shell: bash
       run: cargo install a11ywatch_cli --force
 


### PR DESCRIPTION
* benchmark against pa11y-ci on speed across large websites.

pa11y uses a full node start where the startup is bit faster on new builds since the A11yWatch action needs to perform the following:

1. install rust
1. install a11ywatch_cli
1. install a11ywatch docker images
1. start a11ywatch instance

Takes an additional 1:25 mins. Once we improve the caching for the CLI, it should reduce a lot of the downtime.

Besides the downtime lets see how the testing is handled on a large website that needs to process over a 1,000 pages.

A11yWatch uses a native rust based crawler - this is where the speed shine should show.

3,000 pages for A11yWatchBot ran but, the request to parse the results failed since the size is too large for the current way it's parsed with resolutions in 10mins.

Pa11y-CI  ran 10260 urls on [www.hbo.com](https://www.hbo.com/) in 6 hours and did not finish since it exceeded the time.



