### PR TITLE
bench(large): add large websites coinbase.com,hbo.com

### DIFF
--- a/.github/workflows/bench-action.yml
+++ b/.github/workflows/bench-action.yml
@@ -1,5 +1,9 @@
 name: Bench A11yWatch
 on: [pull_request]
+
+env:
+  AI_DISABLED: true
+
 jobs:
   run-container:
     name: Bench Website Test
@@ -9,12 +13,11 @@ jobs:
       - name: A11yWatch website scan
         uses: ./
         with:
-          WEBSITE_URL: https://a11ywatch.com
-          FAIL_TOTAL_COUNT: 10000
+          WEBSITE_URL: https://www.hbo.com
+          FAIL_TOTAL_COUNT: 10000000000
           EXTERNAL: false
           SITE_WIDE: true
           SUBDOMAINS: false
           TLD: false
           LIST: true
           UPGRADE: false
-          # A11YWATCH_TOKEN: ${{ secrets.A11YWATCH_TOKEN }}

--- a/.github/workflows/bench-pa11y.yml
+++ b/.github/workflows/bench-pa11y.yml
@@ -10,8 +10,8 @@ jobs:
       - name: Install pa11y-ci dependencies.
         run: npm install pa11y-ci  -g
 
-      - name: Run Pa11y-CI Compare.
-        run: pa11y-ci --sitemap https://a11ywatch.com/sitemap.xml | tee pa11y_output.txt
+      - name: Run Pa11y-CI.
+        run: pa11y-ci --sitemap https://www.hbo.com/sitemap.xml | tee pa11y_output.txt
 
       - name: Read pa11y_output file.
         id: pa11y_output

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ On a larger website A11yWatch action runs over 60x-1000x faster depending on CPU
 
 |                        | `libraries`              |
 | :--------------------- | :----------------------- |
-| **`A11yWatch: crawl`** | `35 mins` (✅ **1.00x**) |
+| **`A11yWatch: crawl`** | `13 mins` (✅ **1.00x**) |
 | **`Pa11y-CI: crawl`**  | `50+ hr` (✅ **1.00x**)  |
 
 When `AI_DISABLED` is set to true the run for `A11yWatch` increases to about 50 mins.


### PR DESCRIPTION
* compare coinbase.com with Pa11y-CI and A11yWatch

-- `coinbase`

Pa11y-CI: Cannot crawl due to not being able to dynamically grab links at will or parser.
A11yWatch: 5885 urls in 13mins [view run](https://github.com/a11ywatch/github-actions/actions/runs/2803510101)  - you need to download the raw logs (very large file)

-- `hbo`

Pa11y-CI: Failed CI due to exceeded threshold of 6 hours. Crawled 1,000 urls in 6hours.  55hours+ local
A11yWatch: 7500 urls 19mins
