### PR TITLE
bench(compare): add small-medium benches

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -16,5 +16,3 @@ jobs:
           SUBDOMAINS: true
           TLD: true
           LIST: true
-          UPGRADE: true
-          SLIM: true

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -16,5 +16,5 @@ jobs:
           SUBDOMAINS: true
           TLD: true
           LIST: true
-          UPGRADE: false
-          # A11YWATCH_TOKEN: ${{ secrets.A11YWATCH_TOKEN }}
+          UPGRADE: true
+          SLIM: true

--- a/.github/workflows/bench-action.yml
+++ b/.github/workflows/bench-action.yml
@@ -13,8 +13,8 @@ jobs:
       - name: A11yWatch website scan
         uses: ./
         with:
-          WEBSITE_URL: https://www.hbo.com
-          FAIL_TOTAL_COUNT: 10000000000
+          WEBSITE_URL: https://a11ywatch.com
+          FAIL_TOTAL_COUNT: 0
           EXTERNAL: false
           SITE_WIDE: true
           SUBDOMAINS: false

--- a/.github/workflows/bench-action.yml
+++ b/.github/workflows/bench-action.yml
@@ -13,7 +13,7 @@ jobs:
       - name: A11yWatch website scan
         uses: ./
         with:
-          WEBSITE_URL: https://a11ywatch.com
+          WEBSITE_URL: https://vercel.com
           FAIL_TOTAL_COUNT: 0
           EXTERNAL: false
           SITE_WIDE: true

--- a/.github/workflows/bench-axe.yml
+++ b/.github/workflows/bench-axe.yml
@@ -1,6 +1,9 @@
 name: Bench Axe
 
-on: [pull_request]
+on:
+  pull_request:
+    branches-ignore:
+      - main
 jobs:
   axe:
     runs-on: ubuntu-latest
@@ -13,4 +16,4 @@ jobs:
       - run: npm install -g @axe-core/cli
       - name: Run axe
         run: |
-          axe https://a11ywatch.com
+          axe https://vercel.com

--- a/.github/workflows/bench-axe.yml
+++ b/.github/workflows/bench-axe.yml
@@ -13,5 +13,4 @@ jobs:
       - run: npm install -g @axe-core/cli
       - name: Run axe
         run: |
-          npm i -g @axe-core/cli@next
-          axe https://www.hbo.com --exit
+          axe https://a11ywatch.com

--- a/.github/workflows/bench-pa11y.yml
+++ b/.github/workflows/bench-pa11y.yml
@@ -11,7 +11,7 @@ jobs:
         run: npm install pa11y-ci  -g
 
       - name: Run Pa11y-CI.
-        run: pa11y-ci --sitemap https://a11ywatch.com/sitemap.xml | tee pa11y_output.txt
+        run: pa11y-ci --sitemap https://vercel.com/sitemap.xml | tee pa11y_output.txt
 
       - name: Read pa11y_output file.
         id: pa11y_output

--- a/.github/workflows/bench-pa11y.yml
+++ b/.github/workflows/bench-pa11y.yml
@@ -11,7 +11,7 @@ jobs:
         run: npm install pa11y-ci  -g
 
       - name: Run Pa11y-CI.
-        run: pa11y-ci --sitemap https://www.hbo.com/sitemap.xml | tee pa11y_output.txt
+        run: pa11y-ci --sitemap https://a11ywatch.com/sitemap.xml | tee pa11y_output.txt
 
       - name: Read pa11y_output file.
         id: pa11y_output

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A GitHub action that runs actionable accessibility reports on your website that 
 ### Usage
 
 ```yaml
-- uses: a11ywatch/github-action@v1.10.8
+- uses: a11ywatch/github-action@v1.11.0
   with:
     WEBSITE_URL: ${{ secrets.WEBSITE_URL }}
     SUBDOMAINS: true

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ All inputs are **optional** except $WEBSITE_URL.
 | `DISABLE_PR_STATS`                 | Prevent messaging to the pr results of test.                                                                                                                                                                             | false          |
 | `TOKEN`                            | `GITHUB_TOKEN` (permissions `contents: write` and `pull-requests: write`) or a `repo` scoped [Personal Access Token (PAT)](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token). | `GITHUB_TOKEN` |
 | `A11YWATCH_TOKEN`                  | The A11yWatch API token to use to identify a user.                                                                                                                                                                       |                |
+| `SLIM`                             | Use the gRPC client to gather reports - only displays stats, useful for large websites [no code generation].                                                                                                             |                |
 | `UPGRADE`                          | Upgrade the docker images before testing to latest.                                                                                                                                                                      |                |
 
 ### Action Outputs
@@ -77,6 +78,7 @@ runs with 10 samples:
 | :--------------------- | :-------------------- |
 | **`A11yWatch: crawl`** | `3 s` (✅ **1.00x**)  |
 | **`Pa11y-CI: crawl`**  | `45 s` (✅ **1.00x**) |
+| **`Axe: crawl`**       | `N/A` (✅ **1.00x**)  |
 
 ### crawl-speed (Large Website)
 
@@ -92,6 +94,7 @@ On a larger website A11yWatch action runs over 60x-10,000x+ faster depending on 
 | :--------------------- | :----------------------- |
 | **`A11yWatch: crawl`** | `13 mins` (✅ **1.00x**) |
 | **`Pa11y-CI: crawl`**  | `50+ hr` (✅ **1.00x**)  |
+| **`Axe: crawl`**       | `N/A` (✅ **1.00x**)     |
 
 When `AI_DISABLED` is set to true the run for `A11yWatch` increases to about 39 mins.
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ All inputs are **optional** except $WEBSITE_URL.
 | `DISABLE_PR_STATS`                 | Prevent messaging to the pr results of test.                                                                                                                                                                             | false          |
 | `TOKEN`                            | `GITHUB_TOKEN` (permissions `contents: write` and `pull-requests: write`) or a `repo` scoped [Personal Access Token (PAT)](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token). | `GITHUB_TOKEN` |
 | `A11YWATCH_TOKEN`                  | The A11yWatch API token to use to identify a user.                                                                                                                                                                       |                |
-| `SLIM`                             | Use the gRPC client to gather reports - only displays stats, useful for large websites [no code generation].                                                                                                             |                |
+| `SLIM`                             | Use the gRPC client to gather reports - only displays stats, useful for large websites (no code generation, no outputs, just pure stats) \*note: Must remove action to toggle or set on first time runs.                 |                |
 | `UPGRADE`                          | Upgrade the docker images before testing to latest.                                                                                                                                                                      |                |
 
 ### Action Outputs

--- a/action.yml
+++ b/action.yml
@@ -69,6 +69,10 @@ inputs:
     description: The Computer Vision subscription key to use for advanced AI.
     required: false
     default: ""
+  SLIM:
+    description: Add slim gRPC client usage to gather issue stats.
+    required: false
+    default: false
   UPGRADE:
     description: Upgrade the CLI and docker images to latest across runs.
     required: false
@@ -106,7 +110,7 @@ runs:
       run: |
         curl https://sh.rustup.rs -sSf | sh -s -- -y
         cargo install cargo-update
-        cargo install a11ywatch_cli
+        cargo install a11ywatch_cli ${{ inputs.SLIM == 'true' && '--features grpc' || '' }}
 
     - name: Check for A11yWatch CLI Updates
       shell: bash


### PR DESCRIPTION
1. add medium sized benchmarks

## Small (https://a11ywatch.com)
- a11ywatch 27 pages 4s.
- pa11y 27 pages in 48s
- axe n/a  ( cannot crawl )

## Small-Medium (https://www.rust-lang.org)

- a11ywatch - 38 pages in 9s.
- pa11y n/a (cannot crawl site-map parser faults )
- axe n/a ( cannot crawl )

## Medium (https://vercel.com)

- a11ywatch -  789 pages in  5.4 mins
- pa11y n/a (cannot crawl site-map parser faults )
- axe n/a ( cannot crawl )

## Medium-Large (https://reactjs.org)

- a11ywatch - TODO:.
- pa11y n/a (cannot crawl site-map parser faults )
- axe n/a ( cannot crawl )
 
---
note: axe has issues with their CLI tools across the latest version.
   Also axe has no crawler or github action for this.